### PR TITLE
Proposed wording for high-entrropy inputs, gender neutrality

### DIFF
--- a/draft-sfluhrer-cfrg-ml-kem-security-considerations.md
+++ b/draft-sfluhrer-cfrg-ml-kem-security-considerations.md
@@ -96,7 +96,7 @@ I don't know if we need anything in this section.
 
 This section pertains to KEM (Key Encapsulation Mechanisms) in general, including ML-KEM
 
-To use a KEM, you need to use a high-quality source of entropy during both the key-pair generation and ciphertext generation steps.  If an adversary can recover the random bits used in either of these processes, they can recover the shared secret.  If an adversary can reocver the random bits used during key generation, they can recover the secret key.
+To use a KEM, you need to use a high-quality source of entropy during both the key-pair generation and ciphertext generation steps.  If an adversary can recover the random bits used in either of these processes, they can recover the shared secret.  If an adversary can recover the random bits used during key generation, they can recover the secret key.
 
 Alice needs to keep her private key secret.  It is recommended that she zeroize her private key when she will have no further need of it.
 

--- a/draft-sfluhrer-cfrg-ml-kem-security-considerations.md
+++ b/draft-sfluhrer-cfrg-ml-kem-security-considerations.md
@@ -96,7 +96,7 @@ I don't know if we need anything in this section.
 
 This section pertains to KEM (Key Encapsulation Mechanisms) in general, including ML-KEM
 
-To use a KEM, you need to use good random bits (better terminology here please) during both the public key generation and ciphertext generation steps.  If an adversary can recover the random bits used in either of these processes, he can recover the shared secret.
+To use a KEM, you need to use a high-quality source of entropy during both the key-pair generation and ciphertext generation steps.  If an adversary can recover the random bits used in either of these processes, they can recover the shared secret.  If an adversary can reocver the random bits used during key generation, they can recover the secret key.
 
 Alice needs to keep her private key secret.  It is recommended that she zeroize her private key when she will have no further need of it.
 


### PR DESCRIPTION
Wording:

High-quality entropy source is a first swing at an improvement.

We could lean into the NIST DRBG definitions if we wanted precise terminology, but I feel there's often a contention between precision and clarity, and security consideration documents scream "focus on clarity" to me.  I'm open to dissenting opinions here, of course.

Pronouns:

The adversary is not a specific actor and thus neutral pronouns (they'them) are more suitable. If a specific actor was in mind (e.g., Mallory), rather than just a vague "adversary", then this would be an incorrect change.